### PR TITLE
fix: Payload is now extracted from the request before generating JSONObject, fix #24

### DIFF
--- a/src/main/java/ContinuousIntegration.java
+++ b/src/main/java/ContinuousIntegration.java
@@ -75,12 +75,7 @@ public class ContinuousIntegration extends AbstractHandler
 	// Returns a String[2], the first element is the clone_url, the second is the commit id
 	public String[] processRequestData(HttpServletRequest request){
 		String[] reqData = new String[2];
-		JSONObject requestBody = new JSONObject();
-		try{
-			requestBody = new JSONObject(request.getReader().lines().collect(Collectors.joining(System.lineSeparator())));
-		}catch(IOException e){
-			e.printStackTrace();
-		}
+		JSONObject requestBody = new JSONObject(request.getParameter("payload"));
 		if (requestBody.has("head_commit")) {
 			reqData[0] = requestBody.getJSONObject("repository").getString("clone_url");
 			reqData[1] = requestBody.getJSONObject("head_commit").getString("id");

--- a/src/test/java/MavenTest.java
+++ b/src/test/java/MavenTest.java
@@ -59,13 +59,7 @@ public class MavenTest {
 		HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
 		// Simplified GitHub request payload
 		String payload = "{\"repository\": {\"clone_url\": \"https://github.com/dd2480-group26-2024/continuous_integration.git\"},\"head_commit\": {\"id\": \"22473f129585cad9e0662860d1cc19c9d81e4081\" }}";
-        StringReader stringReader = new StringReader(payload);
-		BufferedReader reader = new BufferedReader(stringReader);
-		try{
-		Mockito.when(request.getReader()).thenReturn(reader);
-		}catch (IOException e){
-			fail("Test failed due to exception: " + e.getMessage());
-		}
+		Mockito.when(request.getParameter("payload")).thenReturn(payload);
 		String[] data = new String[2];
 		data = ci.processRequestData(request);
 		assertArrayEquals(new String[]{"https://github.com/dd2480-group26-2024/continuous_integration.git","22473f129585cad9e0662860d1cc19c9d81e4081"}, data);


### PR DESCRIPTION
Fixed issue #24 by extracting payload before generating a JSONObject.
Corrected the test for _processRequestData_ so the mocked request matches the structure of GitHub's request (parameter "payload" added)