### PR TITLE
fix: Request's payload is extracted properly, fix #24

### DIFF
--- a/src/main/java/ContinuousIntegration.java
+++ b/src/main/java/ContinuousIntegration.java
@@ -11,7 +11,8 @@ import java.io.File;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import java.util.stream.Collectors;
 import org.json.JSONObject;
- 
+
+import java.util.HashMap;
 
 //Java stuff
 
@@ -72,15 +73,15 @@ public class ContinuousIntegration extends AbstractHandler
         response.getWriter().println("CI job done");
     }
 	
-	// Returns a String[2], the first element is the clone_url, the second is the commit id
-	public String[] processRequestData(HttpServletRequest request){
-		String[] reqData = new String[2];
+	// Modifies the HashMap<String, String> passed as parameter. 
+	// Clone url accesible with key "clone_url" and commit id with key "commit_id".
+	public void processRequestData(HttpServletRequest request, HashMap<String, String> map){
 		JSONObject requestBody = new JSONObject(request.getParameter("payload"));
 		if (requestBody.has("head_commit")) {
-			reqData[0] = requestBody.getJSONObject("repository").getString("clone_url");
-			reqData[1] = requestBody.getJSONObject("head_commit").getString("id");
+			map.put("clone_url", requestBody.getJSONObject("repository").getString("clone_url"));
+			map.put("commit_id", requestBody.getJSONObject("head_commit").getString("id"));
 		}
-		return reqData;
+		return;
 	}
  
     // used to start the CI server in command line

--- a/src/main/java/ContinuousIntegration.java
+++ b/src/main/java/ContinuousIntegration.java
@@ -75,12 +75,7 @@ public class ContinuousIntegration extends AbstractHandler
 	// Returns a String[2], the first element is the clone_url, the second is the commit id
 	public String[] processRequestData(HttpServletRequest request){
 		String[] reqData = new String[2];
-		JSONObject requestBody = new JSONObject();
-		try{
-			requestBody = new JSONObject(request.getReader().lines().collect(Collectors.joining(System.lineSeparator())));
-		}catch(IOException e){
-			e.printStackTrace();
-		}
+		JSONObject requestBody = new JSONObject(request.getParameter("payload"));
 		if (requestBody.has("head_commit")) {
 			reqData[0] = requestBody.getJSONObject("repository").getString("clone_url");
 			reqData[1] = requestBody.getJSONObject("head_commit").getString("id");

--- a/src/main/java/ContinuousIntegration.java
+++ b/src/main/java/ContinuousIntegration.java
@@ -9,7 +9,6 @@ import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import java.io.File;
 import org.eclipse.jetty.server.handler.AbstractHandler;
-import java.util.stream.Collectors;
 import org.json.JSONObject;
 
 import java.util.HashMap;
@@ -73,15 +72,10 @@ public class ContinuousIntegration extends AbstractHandler
         response.getWriter().println("CI job done");
     }
 	
-	// Modifies the HashMap<String, String> passed as parameter. 
-	// Clone url accesible with key "clone_url" and commit id with key "commit_id".
-	public void processRequestData(HttpServletRequest request, HashMap<String, String> map){
+	// Extract data from GitHub's request and return a JSONObject
+	public JSONObject processRequestData(HttpServletRequest request){
 		JSONObject requestBody = new JSONObject(request.getParameter("payload"));
-		if (requestBody.has("head_commit")) {
-			map.put("clone_url", requestBody.getJSONObject("repository").getString("clone_url"));
-			map.put("commit_id", requestBody.getJSONObject("head_commit").getString("id"));
-		}
-		return;
+		return requestBody;
 	}
  
     // used to start the CI server in command line

--- a/src/test/java/MavenTest.java
+++ b/src/test/java/MavenTest.java
@@ -59,13 +59,7 @@ public class MavenTest {
 		HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
 		// Simplified GitHub request payload
 		String payload = "{\"repository\": {\"clone_url\": \"https://github.com/dd2480-group26-2024/continuous_integration.git\"},\"head_commit\": {\"id\": \"22473f129585cad9e0662860d1cc19c9d81e4081\" }}";
-        StringReader stringReader = new StringReader(payload);
-		BufferedReader reader = new BufferedReader(stringReader);
-		try{
-		Mockito.when(request.getReader()).thenReturn(reader);
-		}catch (IOException e){
-			fail("Test failed due to exception: " + e.getMessage());
-		}
+		Mockito.when(request.getParameter("payload")).thenReturn(payload);
 		String[] data = new String[2];
 		data = ci.processRequestData(request);
 		assertArrayEquals(new String[]{"https://github.com/dd2480-group26-2024/continuous_integration.git","22473f129585cad9e0662860d1cc19c9d81e4081"}, data);

--- a/src/test/java/MavenTest.java
+++ b/src/test/java/MavenTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.json.JSONObject;
 
 import org.mockito.Mockito;
 import javax.servlet.http.HttpServletRequest;
@@ -57,16 +58,13 @@ public class MavenTest {
 	@Test
 	public void testProcessRequestData(){
 		ContinuousIntegration ci = new ContinuousIntegration();
-		HashMap<String, String> map = new HashMap<>();
-		HashMap<String, String> refMap = new HashMap<>();
 		HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
 		// Simplified GitHub request payload
 		String payload = "{\"repository\": {\"clone_url\": \"https://github.com/dd2480-group26-2024/continuous_integration.git\"},\"head_commit\": {\"id\": \"22473f129585cad9e0662860d1cc19c9d81e4081\" }}";
+		JSONObject expected = new JSONObject(payload);
 		Mockito.when(request.getParameter("payload")).thenReturn(payload);
-		ci.processRequestData(request, map);
-		refMap.put("clone_url","https://github.com/dd2480-group26-2024/continuous_integration.git");
-		refMap.put("commit_id","22473f129585cad9e0662860d1cc19c9d81e4081");
-		assertTrue(map.equals(refMap));
+		JSONObject result = ci.processRequestData(request);
+		assertTrue(result.similar(expected));
 	}
 
 }

--- a/src/test/java/MavenTest.java
+++ b/src/test/java/MavenTest.java
@@ -14,6 +14,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.StringReader;
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.util.HashMap;
 
 public class MavenTest {
 
@@ -56,13 +57,16 @@ public class MavenTest {
 	@Test
 	public void testProcessRequestData(){
 		ContinuousIntegration ci = new ContinuousIntegration();
+		HashMap<String, String> map = new HashMap<>();
+		HashMap<String, String> refMap = new HashMap<>();
 		HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
 		// Simplified GitHub request payload
 		String payload = "{\"repository\": {\"clone_url\": \"https://github.com/dd2480-group26-2024/continuous_integration.git\"},\"head_commit\": {\"id\": \"22473f129585cad9e0662860d1cc19c9d81e4081\" }}";
 		Mockito.when(request.getParameter("payload")).thenReturn(payload);
-		String[] data = new String[2];
-		data = ci.processRequestData(request);
-		assertArrayEquals(new String[]{"https://github.com/dd2480-group26-2024/continuous_integration.git","22473f129585cad9e0662860d1cc19c9d81e4081"}, data);
+		ci.processRequestData(request, map);
+		refMap.put("clone_url","https://github.com/dd2480-group26-2024/continuous_integration.git");
+		refMap.put("commit_id","22473f129585cad9e0662860d1cc19c9d81e4081");
+		assertTrue(map.equals(refMap));
 	}
 
 }


### PR DESCRIPTION
fix: The value of the parameter `payload` is now extracted from the request before generating a JSONOject, in order to match GitHub's request format.
fix: The JSONObject created from the payload is directly returned
fix #24 